### PR TITLE
feat: Use discord display name instead of username

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.9
 
 require (
 	github.com/bufbuild/buf v1.48.0
-	github.com/bwmarrin/discordgo v0.26.1
+	github.com/bwmarrin/discordgo v0.28.1
 	github.com/fzipp/gocyclo v0.6.0
 	github.com/go-critic/go-critic v0.11.5
 	github.com/go-kod/kod v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/bufbuild/protovalidate-go v0.8.0 h1:Xs3kCLCJ4tQiogJ0iOXm+ClKw/KviW3nL
 github.com/bufbuild/protovalidate-go v0.8.0/go.mod h1:JPWZInGm2y2NBg3vKDKdDIkvDjyLv31J3hLH5GIFc/Q=
 github.com/bwmarrin/discordgo v0.26.1 h1:AIrM+g3cl+iYBr4yBxCBp9tD9jR3K7upEjl0d89FRkE=
 github.com/bwmarrin/discordgo v0.26.1/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
+github.com/bwmarrin/discordgo v0.28.1 h1:gXsuo2GBO7NbR6uqmrrBDplPUx2T3nzu775q/Rd1aG4=
+github.com/bwmarrin/discordgo v0.28.1/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/internal/adaptor/discord/discord.go
+++ b/internal/adaptor/discord/discord.go
@@ -158,7 +158,7 @@ func messageHandler(s *discordgo.Session, m *discordgo.MessageCreate) {
 	}
 
 	msg := pb.IncomingMessage{
-		Author:  m.Author.ID,
+		Author:  m.Member.DisplayName(),
 		Content: m.Content,
 		Channel: m.ChannelID,
 		MessageId: m.ID,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Message displays now show the sender's display name instead of an internal identifier, offering a clearer view of who sent each message.
  
- **Chores**
  - Upgraded the Discord integration to the latest version to take advantage of recent improvements and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->